### PR TITLE
Fixed ADB Crypto Key serializing

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:banner="@drawable/ic_banner"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"


### PR DESCRIPTION
Currently, every single time the device is rebooted, the user will be prompted to authenticate an RSA keychain in order to allow remote wireless debugging. This was caused because Crypto objects cannot be serialized into a JSON formatted string, and therefore are unable to be stored in the application's shared preferences. However, the RSA keychain required to establish the connection can be successfully serialized in the device's internal storage. 

The getADBCryptoKey method from the Helper class has been modified to properly store and retrieve the Public RSA Key and the Private RSA Key from the device's internal storage. The keypair is stored in a dedicated partition only accessible by the application package and the Android operating system itself.

The AutoBackup Feature has been disabled to prevent keys from being extracted from the device.

Personally, I have tested the aforementioned modifications on an actual 4th Generation Google Chromecast with Google TV (Based on Android 12) and everything works as expected.



