### PR TITLE
Added option to hide toast messages

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <targetSelectedWithDropDown>
+      <Target>
+        <type value="QUICK_BOOT_TARGET" />
+        <deviceKey>
+          <Key>
+            <type value="VIRTUAL_DEVICE_PATH" />
+            <value value="$USER_HOME$/.android/avd/Generic_Wearable.avd" />
+          </Key>
+        </deviceKey>
+      </Target>
+    </targetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2023-01-12T22:36:42.957108Z" />
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -14,7 +14,6 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 29
         versionCode 106
-        versionName '1.0.7-rs_adbserver_testbranch-tinydisplay_lab-test05'
+        versionName '1.0.7-rs_adbserver_testbranch-tinydisplay_lab-test08'
 
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 29
         versionCode 106
-        versionName '1.0.7-adb-pre'
+        versionName '1.0.7-rs_adbserver_testbranch-rsakeychain_lab-test10'
 
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 29
         versionCode 106
-        versionName '1.0.7-rs_adbserver_testbranch-tinydisplay_lab-build_001'
+        versionName '1.0.7-rs_adbserver_testbranch-tinydisplay_lab-test01'
 
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 29
         versionCode 106
-        versionName '1.0.7-rs_adbserver_testbranch-tinydisplay_lab-test01'
+        versionName '1.0.7-rs_adbserver_testbranch-tinydisplay_lab-test05'
 
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,8 @@ android {
         minSdkVersion 24
         targetSdkVersion 29
         versionCode 106
-        versionName '1.0.7-rs_adbserver_testbranch-main_lab-test25'
+        versionName '1.0.7-rs_adbserver_testbranch-tinydisplay_lab-test08'
+
     }
 
     buildTypes {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 29
         versionCode 106
-        versionName '1.0.7-rs_adbserver_testbranch-tinydisplay_lab-test08'
+        versionName '1.0.7-adb-pre'
 
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 29
         versionCode 106
-        versionName '1.0.7-rs_adbserver_testbranch-rsakeychain_lab-test10'
+        versionName '1.0.7-rs_adbserver_testbranch-tinydisplay_lab-build_001'
 
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 29
         versionCode 106
-        versionName '1.0.7-adb-pre'
+        versionName '1.0.7-rs_adbscrolfix_testbranch-main_lab-test24'
 
     }
 

--- a/app/src/main/java/io/github/virresh/matvt/engine/impl/MouseEmulationEngine.java
+++ b/app/src/main/java/io/github/virresh/matvt/engine/impl/MouseEmulationEngine.java
@@ -246,20 +246,19 @@ public class MouseEmulationEngine {
         return clickBuilder.build();
     }
 
-    private GestureDescription createSwipe (PointF originPoint, int direction, int momentum) {
-        final int DURATION = scrollSpeed + 20;
-        Path clickPath = new Path();
-        PointF lineDirection = new PointF(originPoint.x + (momentum + 75) * PointerControl.dirX[direction], originPoint.y + (momentum + 75) * PointerControl.dirY[direction]);
+    private void createSwipe (PointF originPoint, int direction, int momentum) {
 
+        final int DURATION = 300 - scrollSpeed*10;
+        Path clickPath = new Path();
+        PointF lineDirection = new PointF(originPoint.x + (75 + momentum) * PointerControl.dirX[direction], originPoint.y + (75+momentum) * PointerControl.dirY[direction]);
         mService.shellSwipe((int) originPoint.x, (int) originPoint.y, (int) lineDirection.x, (int) lineDirection.y, DURATION);
 
-        clickPath.moveTo(originPoint.x, originPoint.y);
-        clickPath.lineTo(lineDirection.x, lineDirection.y);
-        GestureDescription.StrokeDescription clickStroke =
-                new GestureDescription.StrokeDescription(clickPath, 0, DURATION);
-        GestureDescription.Builder clickBuilder = new GestureDescription.Builder();
-        clickBuilder.addStroke(clickStroke);
-        return clickBuilder.build();
+        try {
+            Thread.sleep(DURATION + 200);
+        } catch (InterruptedException e) {
+            Log.e(LOG_TAG, "Thread interrupted: ",e);
+        }
+
     }
 
     public boolean perform (KeyEvent keyEvent) {

--- a/app/src/main/java/io/github/virresh/matvt/engine/impl/MouseEmulationEngine.java
+++ b/app/src/main/java/io/github/virresh/matvt/engine/impl/MouseEmulationEngine.java
@@ -73,7 +73,7 @@ public class MouseEmulationEngine {
 
     public static int scrollSpeed;
 
-    public static boolean areAlertsHidden;
+    public static boolean isHideToastsOptionEnabled;
 
     public static boolean isBossKeyDisabled;
 
@@ -521,7 +521,7 @@ public class MouseEmulationEngine {
 
     private void showToast(String message){
 
-        if(!areAlertsHidden){
+        if(!isHideToastsOptionEnabled){
             Toast.makeText(mService,message,Toast.LENGTH_SHORT).show();
         }else {
             Log.i(LOG_TAG,message);

--- a/app/src/main/java/io/github/virresh/matvt/engine/impl/MouseEmulationEngine.java
+++ b/app/src/main/java/io/github/virresh/matvt/engine/impl/MouseEmulationEngine.java
@@ -73,6 +73,8 @@ public class MouseEmulationEngine {
 
     public static int scrollSpeed;
 
+    public static boolean areAlertsHidden;
+
     public static boolean isBossKeyDisabled;
 
     public static boolean isBossKeySetToToggle;
@@ -277,8 +279,7 @@ public class MouseEmulationEngine {
                 waitToChange();
                 if (isEnabled){
                     isInScrollMode = !isInScrollMode;
-                    Toast.makeText(mService, isInScrollMode ? "Scroll Mode: Enabled" : "Scroll Mode: Disabled",
-                            Toast.LENGTH_SHORT).show();
+                    showToast(isInScrollMode ? "Scroll Mode: Enabled" : "Scroll Mode: Disabled");
                     return true;
                 }
             }
@@ -292,7 +293,7 @@ public class MouseEmulationEngine {
                     isInScrollMode = false;
                 } else if (isEnabled && !isInScrollMode) {
                     // Mouse Mode -> Scroll Mode
-                    Toast.makeText(mService, "Scroll Mode", Toast.LENGTH_SHORT).show();
+                    showToast("Scroll Mode");
                     isInScrollMode = true;
                 } else if (!isEnabled) {
                     // Dpad mode -> Mouse mode
@@ -313,14 +314,14 @@ public class MouseEmulationEngine {
                 // mouse already enabled, disable it and make it go away
                 this.isEnabled = false;
                 mPointerControl.disappear();
-                Toast.makeText(mService, "Dpad Mode", Toast.LENGTH_SHORT).show();
+                showToast("D-Pad Mode");
                 return true;
             } else {
                 // mouse is disabled, enable it, reset it and show it
                 this.isEnabled = true;
                 mPointerControl.reset();
                 mPointerControl.reappear();
-                Toast.makeText(mService, "Mouse/Scroll", Toast.LENGTH_SHORT).show();
+                showToast("Mouse/Scroll mode");
             }
         }
 
@@ -508,15 +509,27 @@ public class MouseEmulationEngine {
             isInScrollMode = false;
             mPointerControl.reset();
             mPointerControl.reappear();
-            Toast.makeText(mService, "Mouse Mode", Toast.LENGTH_SHORT).show();
+            showToast("Mouse Mode");
         }
         else {
             // Disable Mouse Mode
             this.isEnabled = false;
             mPointerControl.disappear();
-            Toast.makeText(mService, "D-Pad Mode", Toast.LENGTH_SHORT).show();
+            showToast("D-Pad Mode");
         }
     }
+
+    private void showToast(String message){
+
+        if(!areAlertsHidden){
+            Toast.makeText(mService,message,Toast.LENGTH_SHORT).show();
+        }else {
+            Log.i(LOG_TAG,message);
+        }
+
+    }
+
+
 
     /**
      * Simple count down timer for checking keypress duration

--- a/app/src/main/java/io/github/virresh/matvt/engine/impl/MouseEmulationEngine.java
+++ b/app/src/main/java/io/github/virresh/matvt/engine/impl/MouseEmulationEngine.java
@@ -248,19 +248,20 @@ public class MouseEmulationEngine {
         return clickBuilder.build();
     }
 
-    private void createSwipe (PointF originPoint, int direction, int momentum) {
-
-        final int DURATION = 300 - scrollSpeed*10;
+    private GestureDescription createSwipe (PointF originPoint, int direction, int momentum) {
+        final int DURATION = scrollSpeed + 20;
         Path clickPath = new Path();
-        PointF lineDirection = new PointF(originPoint.x + (75 + momentum) * PointerControl.dirX[direction], originPoint.y + (75+momentum) * PointerControl.dirY[direction]);
+        PointF lineDirection = new PointF(originPoint.x + (momentum + 75) * PointerControl.dirX[direction], originPoint.y + (momentum + 75) * PointerControl.dirY[direction]);
+
         mService.shellSwipe((int) originPoint.x, (int) originPoint.y, (int) lineDirection.x, (int) lineDirection.y, DURATION);
 
-        try {
-            Thread.sleep(DURATION + 200);
-        } catch (InterruptedException e) {
-            Log.e(LOG_TAG, "Thread interrupted: ",e);
-        }
-
+        clickPath.moveTo(originPoint.x, originPoint.y);
+        clickPath.lineTo(lineDirection.x, lineDirection.y);
+        GestureDescription.StrokeDescription clickStroke =
+                new GestureDescription.StrokeDescription(clickPath, 0, DURATION);
+        GestureDescription.Builder clickBuilder = new GestureDescription.Builder();
+        clickBuilder.addStroke(clickStroke);
+        return clickBuilder.build();
     }
 
     public boolean perform (KeyEvent keyEvent) {

--- a/app/src/main/java/io/github/virresh/matvt/gui/GuiActivity.java
+++ b/app/src/main/java/io/github/virresh/matvt/gui/GuiActivity.java
@@ -69,7 +69,7 @@ public class GuiActivity extends AppCompatActivity {
 
         // don't like to advertise in the product, but need to mention here
         // need to increase visibility of the open source version
-        gui_about.setText("MATVT v" + BuildConfig.VERSION_NAME + "\nThis is an open source project. It's available for free and will always be. If you find issues / would like to help in improving this project, please contribute at \nhttps://github.com/virresh/matvt");
+        gui_about.setText("MATVT v" + BuildConfig.VERSION_NAME + "\n\nThis is an open source project. It's available for free and will always be. If you find issues / would like to help in improving this project, please contribute at \nhttps://github.com/virresh/matvt");
 
         // render icon style dropdown
         IconStyleSpinnerAdapter iconStyleSpinnerAdapter = new IconStyleSpinnerAdapter(this, R.layout.spinner_icon_text_gui, R.id.textView, IconStyleSpinnerAdapter.getResourceList());

--- a/app/src/main/java/io/github/virresh/matvt/gui/GuiActivity.java
+++ b/app/src/main/java/io/github/virresh/matvt/gui/GuiActivity.java
@@ -187,6 +187,14 @@ public class GuiActivity extends AppCompatActivity {
         boolean bordered = Helper.getMouseBordered(ctx);
         cb_mouse_bordered.setChecked(bordered);
 
+        boolean toastVisibility;
+        if(!Helper.hasDeviceTypeBeenIdentified(ctx)){
+            toastVisibility = Helper.determineDeviceTypePolicy(ctx);
+        }else{
+            toastVisibility = Helper.getHideToastAlerts(ctx);
+        }
+        cb_hide_toasts.setChecked(toastVisibility);
+
         boolean bossKeyStatus = Helper.isBossKeyDisabled(ctx);
         cb_disable_bossKey.setChecked(bossKeyStatus);
 

--- a/app/src/main/java/io/github/virresh/matvt/gui/GuiActivity.java
+++ b/app/src/main/java/io/github/virresh/matvt/gui/GuiActivity.java
@@ -187,14 +187,7 @@ public class GuiActivity extends AppCompatActivity {
         boolean bordered = Helper.getMouseBordered(ctx);
         cb_mouse_bordered.setChecked(bordered);
 
-        boolean toastVisibility;
-
-        if(!Helper.hasDeviceTypeBeenIdentified(ctx)){
-            toastVisibility = Helper.determineDeviceTypePolicy(ctx);
-            Helper.setHideToastsOptionEnabled(ctx,toastVisibility);
-        }else{
-            toastVisibility = Helper.isHideToastOptionEnabled(ctx);
-        }
+        boolean toastVisibility = Helper.isHideToastOptionEnabled(ctx);
 
         cb_hide_toasts.setChecked(toastVisibility);
 

--- a/app/src/main/java/io/github/virresh/matvt/gui/GuiActivity.java
+++ b/app/src/main/java/io/github/virresh/matvt/gui/GuiActivity.java
@@ -150,7 +150,7 @@ public class GuiActivity extends AppCompatActivity {
 
         cb_hide_toasts.setOnCheckedChangeListener((compoundButton, b) ->{
             Helper.setHideToastAlerts(getApplicationContext(), b);
-            MouseEmulationEngine.areAlertsHidden = b;
+            MouseEmulationEngine.isHideToastsOptionEnabled = b;
         });
 
         cb_disable_bossKey.setOnCheckedChangeListener(((compoundButton, value) -> {

--- a/app/src/main/java/io/github/virresh/matvt/gui/GuiActivity.java
+++ b/app/src/main/java/io/github/virresh/matvt/gui/GuiActivity.java
@@ -70,7 +70,7 @@ public class GuiActivity extends AppCompatActivity {
 
         // don't like to advertise in the product, but need to mention here
         // need to increase visibility of the open source version
-        gui_about.setText("MATVT v" + BuildConfig.VERSION_NAME + "\n\nThis is an open source project. It's available for free and will always be. If you find issues / would like to help in improving this project, please contribute at \nhttps://github.com/virresh/matvt");
+        gui_about.setText("MATVT v" + BuildConfig.VERSION_NAME + "\nThis is an open source project. It's available for free and will always be. If you find issues / would like to help in improving this project, please contribute at \nhttps://github.com/virresh/matvt");
 
         // render icon style dropdown
         IconStyleSpinnerAdapter iconStyleSpinnerAdapter = new IconStyleSpinnerAdapter(this, R.layout.spinner_icon_text_gui, R.id.textView, IconStyleSpinnerAdapter.getResourceList());

--- a/app/src/main/java/io/github/virresh/matvt/gui/GuiActivity.java
+++ b/app/src/main/java/io/github/virresh/matvt/gui/GuiActivity.java
@@ -32,7 +32,7 @@ import static io.github.virresh.matvt.engine.impl.MouseEmulationEngine.scrollSpe
 
 public class GuiActivity extends AppCompatActivity {
     CountDownTimer repopulate;
-    CheckBox cb_mouse_bordered, cb_disable_bossKey, cb_behaviour_bossKey;
+    CheckBox cb_mouse_bordered, cb_disable_bossKey, cb_behaviour_bossKey, cb_hide_toasts;
     TextView gui_acc_perm, gui_acc_serv, gui_overlay_perm, gui_overlay_serv, gui_about;
 
     EditText et_override;
@@ -60,6 +60,7 @@ public class GuiActivity extends AppCompatActivity {
         et_override = findViewById(R.id.et_override);
 
         cb_mouse_bordered = findViewById(R.id.cb_border_window);
+        cb_hide_toasts = findViewById(R.id.cb_hide_toasts);
         cb_disable_bossKey = findViewById(R.id.cb_disable_bossKey);
         cb_behaviour_bossKey = findViewById(R.id.cb_behaviour_bossKey);
 
@@ -69,7 +70,7 @@ public class GuiActivity extends AppCompatActivity {
 
         // don't like to advertise in the product, but need to mention here
         // need to increase visibility of the open source version
-        gui_about.setText("MATVT v" + BuildConfig.VERSION_NAME + "\nThis is an open source project. It's available for free and will always be. If you find issues / would like to help in improving this project, please contribute at \nhttps://github.com/virresh/matvt");
+        gui_about.setText("MATVT v" + BuildConfig.VERSION_NAME + "\n\nThis is an open source project. It's available for free and will always be. If you find issues / would like to help in improving this project, please contribute at \nhttps://github.com/virresh/matvt");
 
         // render icon style dropdown
         IconStyleSpinnerAdapter iconStyleSpinnerAdapter = new IconStyleSpinnerAdapter(this, R.layout.spinner_icon_text_gui, R.id.textView, IconStyleSpinnerAdapter.getResourceList());
@@ -145,6 +146,11 @@ public class GuiActivity extends AppCompatActivity {
         cb_mouse_bordered.setOnCheckedChangeListener((compoundButton, b) -> {
             Helper.setMouseBordered(getApplicationContext(), b);
             PointerControl.isBordered = b;
+        });
+
+        cb_hide_toasts.setOnCheckedChangeListener((compoundButton, b) ->{
+            Helper.setHideToastAlerts(getApplicationContext(), b);
+            MouseEmulationEngine.areAlertsHidden = b;
         });
 
         cb_disable_bossKey.setOnCheckedChangeListener(((compoundButton, value) -> {

--- a/app/src/main/java/io/github/virresh/matvt/gui/GuiActivity.java
+++ b/app/src/main/java/io/github/virresh/matvt/gui/GuiActivity.java
@@ -148,10 +148,10 @@ public class GuiActivity extends AppCompatActivity {
             PointerControl.isBordered = b;
         });
 
-        cb_hide_toasts.setOnCheckedChangeListener((compoundButton, b) ->{
-            Helper.setHideToastAlerts(getApplicationContext(), b);
-            MouseEmulationEngine.isHideToastsOptionEnabled = b;
-        });
+        cb_hide_toasts.setOnCheckedChangeListener(((compoundButton, value) -> {
+            Helper.setHideToastsOptionEnabled(getApplicationContext(), value);
+            MouseEmulationEngine.isHideToastsOptionEnabled = value;
+        }));
 
         cb_disable_bossKey.setOnCheckedChangeListener(((compoundButton, value) -> {
             Helper.setBossKeyDisabled(getApplicationContext(), value);
@@ -188,12 +188,16 @@ public class GuiActivity extends AppCompatActivity {
         cb_mouse_bordered.setChecked(bordered);
 
         boolean toastVisibility;
+
         if(!Helper.hasDeviceTypeBeenIdentified(ctx)){
             toastVisibility = Helper.determineDeviceTypePolicy(ctx);
+            Helper.setHideToastsOptionEnabled(ctx,toastVisibility);
         }else{
-            toastVisibility = Helper.getHideToastAlerts(ctx);
+            toastVisibility = Helper.isHideToastOptionEnabled(ctx);
         }
+
         cb_hide_toasts.setChecked(toastVisibility);
+
 
         boolean bossKeyStatus = Helper.isBossKeyDisabled(ctx);
         cb_disable_bossKey.setChecked(bossKeyStatus);

--- a/app/src/main/java/io/github/virresh/matvt/helper/Helper.java
+++ b/app/src/main/java/io/github/virresh/matvt/helper/Helper.java
@@ -29,6 +29,7 @@ public class Helper {
     public static Context helperContext;
 
     static final String PREFS_ID = "MATVT";
+    static final String PREF_ALERTS_HIDE_TOASTS = "HIDE_ALERTS";
     static final String PREF_KEY_CB_OVERRIDE_STAT = "CB_OVERRIDE_STAT";
     static final String PREF_KEY_CB_OVERRIDE_VAL = "CB_OVERRIDE_VAL";
     static final String PREF_KEY_MOUSE_ICON = "MOUSE_ICON";
@@ -144,6 +145,18 @@ public class Helper {
     public static boolean getMouseBordered(Context ctx) {
         SharedPreferences sp = ctx.getSharedPreferences(PREFS_ID, Context.MODE_PRIVATE);
         return sp.getBoolean(PREF_KEY_MOUSE_BORDERED, false);
+    }
+    @SuppressLint("ApplySharedPref")
+    public static void setHideToastAlerts(Context ctx, Boolean val){
+        SharedPreferences sp = ctx.getSharedPreferences(PREFS_ID,Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sp.edit();
+        editor.putBoolean(PREF_ALERTS_HIDE_TOASTS,val);
+        editor.commit();
+    }
+
+    public static boolean getHideToastAlerts(Context ctx){
+        SharedPreferences sp = ctx.getSharedPreferences(PREFS_ID, Context.MODE_PRIVATE);
+        return sp.getBoolean(PREF_ALERTS_HIDE_TOASTS, false);
     }
 
     @SuppressLint("ApplySharedPref")

--- a/app/src/main/java/io/github/virresh/matvt/helper/Helper.java
+++ b/app/src/main/java/io/github/virresh/matvt/helper/Helper.java
@@ -4,11 +4,9 @@ import android.accessibilityservice.AccessibilityServiceInfo;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.content.pm.PackageManager;
 import android.os.Build;
 import android.provider.Settings;
 
-import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityManager;

--- a/app/src/main/java/io/github/virresh/matvt/helper/Helper.java
+++ b/app/src/main/java/io/github/virresh/matvt/helper/Helper.java
@@ -151,14 +151,14 @@ public class Helper {
         return sp.getBoolean(PREF_KEY_MOUSE_BORDERED, false);
     }
     @SuppressLint("ApplySharedPref")
-    public static void setHideToastAlerts(Context ctx, Boolean val){
+    public static void setHideToastsOptionEnabled(Context ctx, Boolean val){
         SharedPreferences sp = ctx.getSharedPreferences(PREFS_ID,Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = sp.edit();
         editor.putBoolean(PREF_ALERTS_HIDE_TOASTS,val);
         editor.commit();
     }
 
-    public static boolean getHideToastAlerts(Context ctx){
+    public static boolean isHideToastOptionEnabled(Context ctx){
         SharedPreferences sp = ctx.getSharedPreferences(PREFS_ID, Context.MODE_PRIVATE);
         return sp.getBoolean(PREF_ALERTS_HIDE_TOASTS, false);
     }

--- a/app/src/main/java/io/github/virresh/matvt/helper/Helper.java
+++ b/app/src/main/java/io/github/virresh/matvt/helper/Helper.java
@@ -4,12 +4,15 @@ import android.accessibilityservice.AccessibilityServiceInfo;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.os.Build;
 import android.provider.Settings;
 
+import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityManager;
+
 
 import androidx.annotation.RequiresApi;
 
@@ -40,6 +43,7 @@ public class Helper {
     static final String PREF_KEY_CB_BEHAVIOUR_BOSSKEY = "CB_BEHAVIOUR_BOSSKEY";
     static final String IO_PUBLICKEY_FILENAME = "public_key.bin";
     static final String IO_PRIVATEKEY_FILENAME = "private_key.bin";
+    static final String PREF_HOST_DEVICETYPE = "DEVICE_TYPE";
 
 
     public static boolean isAccessibilityDisabled(Context ctx) {
@@ -230,6 +234,33 @@ public class Helper {
 
 
         return crypto;
+    }
+
+    public static boolean hasDeviceTypeBeenIdentified(Context ctx){
+        SharedPreferences sp = ctx.getSharedPreferences(PREFS_ID, Context.MODE_PRIVATE);
+        return sp.contains(PREF_HOST_DEVICETYPE);
+    }
+
+    public static boolean determineDeviceTypePolicy(Context ctx){
+
+        SharedPreferences sp = ctx.getSharedPreferences(PREFS_ID,Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sp.edit();
+        DisplayMetrics metrics = ctx.getResources().getDisplayMetrics();
+        Boolean deviceTypeRecommendedSettings;
+        double screenSize;
+
+        screenSize = Math.sqrt(Math.pow(metrics.widthPixels/metrics.xdpi,2) + Math.pow(metrics.heightPixels/metrics.ydpi,2));
+
+        if (screenSize < 4.5 || ctx.getPackageManager().hasSystemFeature(PackageManager.FEATURE_WATCH)){
+            editor.putString(PREF_HOST_DEVICETYPE,"WEARABLE");
+            deviceTypeRecommendedSettings = true;
+        }else{
+            editor.putString(PREF_HOST_DEVICETYPE,"NOT_A_WEARABLE");
+            deviceTypeRecommendedSettings = false;
+        }
+
+        editor.commit();
+        return deviceTypeRecommendedSettings;
     }
 
 }

--- a/app/src/main/java/io/github/virresh/matvt/helper/Helper.java
+++ b/app/src/main/java/io/github/virresh/matvt/helper/Helper.java
@@ -43,8 +43,6 @@ public class Helper {
     static final String PREF_KEY_CB_BEHAVIOUR_BOSSKEY = "CB_BEHAVIOUR_BOSSKEY";
     static final String IO_PUBLICKEY_FILENAME = "public_key.bin";
     static final String IO_PRIVATEKEY_FILENAME = "private_key.bin";
-    static final String PREF_HOST_DEVICETYPE = "DEVICE_TYPE";
-
 
     public static boolean isAccessibilityDisabled(Context ctx) {
         return !isAccServiceInstalled(ctx.getPackageName() + "/.services.MouseEventService", ctx);
@@ -234,33 +232,6 @@ public class Helper {
 
 
         return crypto;
-    }
-
-    public static boolean hasDeviceTypeBeenIdentified(Context ctx){
-        SharedPreferences sp = ctx.getSharedPreferences(PREFS_ID, Context.MODE_PRIVATE);
-        return sp.contains(PREF_HOST_DEVICETYPE);
-    }
-
-    public static boolean determineDeviceTypePolicy(Context ctx){
-
-        SharedPreferences sp = ctx.getSharedPreferences(PREFS_ID,Context.MODE_PRIVATE);
-        SharedPreferences.Editor editor = sp.edit();
-        DisplayMetrics metrics = ctx.getResources().getDisplayMetrics();
-        Boolean deviceTypeRecommendedSettings;
-        double screenSize;
-
-        screenSize = Math.sqrt(Math.pow(metrics.widthPixels/metrics.xdpi,2) + Math.pow(metrics.heightPixels/metrics.ydpi,2));
-
-        if (screenSize < 4.5 || ctx.getPackageManager().hasSystemFeature(PackageManager.FEATURE_WATCH)){
-            editor.putString(PREF_HOST_DEVICETYPE,"WEARABLE");
-            deviceTypeRecommendedSettings = true;
-        }else{
-            editor.putString(PREF_HOST_DEVICETYPE,"NOT_A_WEARABLE");
-            deviceTypeRecommendedSettings = false;
-        }
-
-        editor.commit();
-        return deviceTypeRecommendedSettings;
     }
 
 }

--- a/app/src/main/java/io/github/virresh/matvt/services/MouseEventService.java
+++ b/app/src/main/java/io/github/virresh/matvt/services/MouseEventService.java
@@ -190,7 +190,7 @@ public class MouseEventService extends AccessibilityService {
 //                Log.i(TAG_NAME, "Succeeded ? ===> " + response.isSuccessful());
 //            }
 //        });
-        sendShellInput("swipe " + x1.toString() + " " + y1.toString() + " " + x2.toString() + " " + y2.toString() + " " + duration.toString());
+        sendShellInput("swipe " + x1.toString() + " " + y1.toString() + " " + x2.toString() + " " + y2.toString());
     }
 
     public void shellTap(Integer x, Integer y) {

--- a/app/src/main/java/io/github/virresh/matvt/services/MouseEventService.java
+++ b/app/src/main/java/io/github/virresh/matvt/services/MouseEventService.java
@@ -71,6 +71,7 @@ public class MouseEventService extends AccessibilityService {
         bossKey = KeyEvent.KEYCODE_VOLUME_MUTE;
         PointerControl.isBordered = Helper.getMouseBordered(this);
         scrollSpeed = Helper.getScrollSpeed(this);
+        MouseEmulationEngine.isHideToastsOptionEnabled = Helper.isHideToastOptionEnabled(this);
         MouseEmulationEngine.isBossKeyDisabled = Helper.isBossKeyDisabled(this);
         MouseEmulationEngine.isBossKeySetToToggle = Helper.isBossKeySetToToggle(this);
         if (Helper.isOverriding(this)) bossKey = Helper.getBossKeyValue(this);

--- a/app/src/main/java/io/github/virresh/matvt/services/MouseEventService.java
+++ b/app/src/main/java/io/github/virresh/matvt/services/MouseEventService.java
@@ -189,7 +189,7 @@ public class MouseEventService extends AccessibilityService {
 //                Log.i(TAG_NAME, "Succeeded ? ===> " + response.isSuccessful());
 //            }
 //        });
-        sendShellInput("swipe " + x1.toString() + " " + y1.toString() + " " + x2.toString() + " " + y2.toString());
+        sendShellInput("swipe " + x1.toString() + " " + y1.toString() + " " + x2.toString() + " " + y2.toString() + " " + duration.toString());
     }
 
     public void shellTap(Integer x, Integer y) {

--- a/app/src/main/res/layout/activity_main_gui.xml
+++ b/app/src/main/res/layout/activity_main_gui.xml
@@ -218,13 +218,25 @@
             android:textSize="20sp" />
 
         <CheckBox
+            android:id="@+id/cb_hide_toasts"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layoutDirection="rtl"
+            android:nextFocusUp="@id/cb_border_window"
+            android:buttonTint="@color/white"
+            android:text="Hide toast messages (Recommended for smaller displays)"
+            android:textColor="@color/white"
+            android:textSize="20sp"/>
+
+        <CheckBox
             android:id="@+id/cb_disable_bossKey"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
             android:buttonTint="@color/white"
             android:layoutDirection="rtl"
-            android:nextFocusUp="@id/cb_border_window"
+            android:nextFocusUp="@id/cb_hide_toasts"
             android:text="Disable Boss Key (useful for full size remotes)"
             android:textColor="@color/white"
             android:textSize="20sp" />


### PR DESCRIPTION
A new option was added into the Other Settings section to enable users to hide toast alerts If they want to do so. For people running the app on wearables this could be really practical. 