### PR TITLE
Fixed endless scroll bug  + ghost clicks bug + latency issues

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <runningDeviceTargetSelectedWithDropDown>
+      <Target>
+        <type value="RUNNING_DEVICE_TARGET" />
+        <deviceKey>
+          <Key>
+            <type value="SERIAL_NUMBER" />
+            <value value="192.168.0.24:5555" />
+          </Key>
+        </deviceKey>
+      </Target>
+    </runningDeviceTargetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2023-05-02T23:20:55.031864Z" />
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -14,7 +14,6 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 29
         versionCode 106
-        versionName '1.0.7-rs_adbscrolfix_testbranch-tinydisplay_refresh_lab-test01'
+        versionName '1.0.7-adb-pre'
 
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 29
         versionCode 106
-        versionName '1.0.7-rs_adbscrolfix_testbranch-main_lab-test24'
+        versionName '1.0.7-rs_adbscrolfix_testbranch-tinydisplay_refresh_lab-test01'
 
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 29
         versionCode 106
-        versionName '1.0.7-adb-pre'
+        versionName '1.0.7-rs_adbscrolfix_testbranch-main_lab-test24'
 
     }
 

--- a/app/src/main/java/io/github/virresh/matvt/engine/impl/MouseEmulationEngine.java
+++ b/app/src/main/java/io/github/virresh/matvt/engine/impl/MouseEmulationEngine.java
@@ -246,20 +246,19 @@ public class MouseEmulationEngine {
         return clickBuilder.build();
     }
 
-    private GestureDescription createSwipe (PointF originPoint, int direction, int momentum) {
-        final int DURATION = scrollSpeed + 20;
-        Path clickPath = new Path();
-        PointF lineDirection = new PointF(originPoint.x + (momentum + 75) * PointerControl.dirX[direction], originPoint.y + (momentum + 75) * PointerControl.dirY[direction]);
+    private void createSwipe (PointF originPoint, int direction, int momentum) {
 
+        final int DURATION = 300 - scrollSpeed*10;
+        Path clickPath = new Path();
+        PointF lineDirection = new PointF(originPoint.x + (75 + momentum) * PointerControl.dirX[direction], originPoint.y + (75+momentum) * PointerControl.dirY[direction]);
         mService.shellSwipe((int) originPoint.x, (int) originPoint.y, (int) lineDirection.x, (int) lineDirection.y, DURATION);
 
-        clickPath.moveTo(originPoint.x, originPoint.y);
-        clickPath.lineTo(lineDirection.x, lineDirection.y);
-        GestureDescription.StrokeDescription clickStroke =
-                new GestureDescription.StrokeDescription(clickPath, 0, DURATION);
-        GestureDescription.Builder clickBuilder = new GestureDescription.Builder();
-        clickBuilder.addStroke(clickStroke);
-        return clickBuilder.build();
+        try {
+            Thread.sleep(DURATION + 200);
+        } catch (InterruptedException e) {
+            Log.e(LOG_TAG, "Thread interrupted: ",e);
+        }
+
     }
 
     public boolean perform (KeyEvent keyEvent) {

--- a/app/src/main/java/io/github/virresh/matvt/engine/impl/MouseEmulationEngine.java
+++ b/app/src/main/java/io/github/virresh/matvt/engine/impl/MouseEmulationEngine.java
@@ -19,7 +19,6 @@ import android.view.InputDevice;
 import android.view.InputEvent;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
-import android.view.View;
 import android.view.accessibility.AccessibilityNodeInfo;
 import android.view.accessibility.AccessibilityWindowInfo;
 import android.view.inputmethod.InputMethodManager;
@@ -28,9 +27,6 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -42,7 +38,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 
-import io.github.virresh.matvt.helper.Helper;
 import io.github.virresh.matvt.services.MouseEventService;
 import io.github.virresh.matvt.view.MouseCursorView;
 import io.github.virresh.matvt.view.OverlayView;
@@ -56,7 +51,7 @@ public class MouseEmulationEngine {
 
     CountDownTimer disappearTimer;
 
-    CountDownTimer swipeGestureCooldown;
+    CountDownTimer swipeGestureCoolDown;
 
     private boolean isQueueEmpty = true;
 
@@ -261,7 +256,7 @@ public class MouseEmulationEngine {
         PointF lineDirection = new PointF(originPoint.x + (75 + momentum) * PointerControl.dirX[direction], originPoint.y + (75+momentum) * PointerControl.dirY[direction]);
         mService.shellSwipe((int) originPoint.x, (int) originPoint.y, (int) lineDirection.x, (int) lineDirection.y, DURATION);
 
-        swipeGestureCooldown =  new CountDownTimer(DURATION+200,100) {
+        swipeGestureCoolDown =  new CountDownTimer(DURATION+200,100) {
             @Override
             public void onTick(long millisUntilFinished) {}
             @Override
@@ -270,7 +265,7 @@ public class MouseEmulationEngine {
             }
         };
 
-        swipeGestureCooldown.start();
+        swipeGestureCoolDown.start();
 
         momentumStack += 1;
 

--- a/app/src/main/java/io/github/virresh/matvt/engine/impl/MouseEmulationEngine.java
+++ b/app/src/main/java/io/github/virresh/matvt/engine/impl/MouseEmulationEngine.java
@@ -56,6 +56,10 @@ public class MouseEmulationEngine {
 
     CountDownTimer disappearTimer;
 
+    CountDownTimer swipeGestureCooldown;
+
+    private boolean isQueueEmpty = true;
+
     private boolean isInScrollMode = false;
 
     // service which started this engine
@@ -185,7 +189,7 @@ public class MouseEmulationEngine {
                 mPointerControl.reappear();
 //                mService.dispatchGesture(createSwipe(originPoint, direction, 20 + momentumStack), null, null);
                 createSwipe(originPoint, direction, 20 + momentumStack);
-                momentumStack += 1;
+                //momentumStack += 1;
                 timerHandler.postDelayed(this, 30);
             }
         };
@@ -202,7 +206,7 @@ public class MouseEmulationEngine {
                 mPointerControl.reappear();
 //                mService.dispatchGesture(createSwipe(originPoint, direction, 20 + momentumStack), null, null);
                 createSwipe(originPoint, direction, 20 + momentumStack);
-                momentumStack += 1;
+                //momentumStack += 1;
                 timerHandler.postDelayed(this, 30);
             }
         };
@@ -248,16 +252,35 @@ public class MouseEmulationEngine {
 
     private void createSwipe (PointF originPoint, int direction, int momentum) {
 
+        if(!isQueueEmpty) return;
+
+        isQueueEmpty = false;
+
         final int DURATION = 300 - scrollSpeed*10;
         Path clickPath = new Path();
         PointF lineDirection = new PointF(originPoint.x + (75 + momentum) * PointerControl.dirX[direction], originPoint.y + (75+momentum) * PointerControl.dirY[direction]);
         mService.shellSwipe((int) originPoint.x, (int) originPoint.y, (int) lineDirection.x, (int) lineDirection.y, DURATION);
 
+        swipeGestureCooldown =  new CountDownTimer(DURATION+200,100) {
+            @Override
+            public void onTick(long millisUntilFinished) {}
+            @Override
+            public void onFinish() {
+                isQueueEmpty = true;
+            }
+        };
+
+        swipeGestureCooldown.start();
+
+        momentumStack += 1;
+
+        /*
         try {
             Thread.sleep(DURATION + 200);
         } catch (InterruptedException e) {
             Log.e(LOG_TAG, "Thread interrupted: ",e);
         }
+         */
 
     }
 

--- a/app/src/main/java/io/github/virresh/matvt/gui/GuiActivity.java
+++ b/app/src/main/java/io/github/virresh/matvt/gui/GuiActivity.java
@@ -69,7 +69,7 @@ public class GuiActivity extends AppCompatActivity {
 
         // don't like to advertise in the product, but need to mention here
         // need to increase visibility of the open source version
-        gui_about.setText("MATVT v" + BuildConfig.VERSION_NAME + "\nThis is an open source project. It's available for free and will always be. If you find issues / would like to help in improving this project, please contribute at \nhttps://github.com/virresh/matvt");
+        gui_about.setText("MATVT v" + BuildConfig.VERSION_NAME + "\n\nThis is an open source project. It's available for free and will always be. If you find issues / would like to help in improving this project, please contribute at \nhttps://github.com/virresh/matvt");
 
         // render icon style dropdown
         IconStyleSpinnerAdapter iconStyleSpinnerAdapter = new IconStyleSpinnerAdapter(this, R.layout.spinner_icon_text_gui, R.id.textView, IconStyleSpinnerAdapter.getResourceList());

--- a/app/src/main/java/io/github/virresh/matvt/services/MouseEventService.java
+++ b/app/src/main/java/io/github/virresh/matvt/services/MouseEventService.java
@@ -189,7 +189,7 @@ public class MouseEventService extends AccessibilityService {
 //                Log.i(TAG_NAME, "Succeeded ? ===> " + response.isSuccessful());
 //            }
 //        });
-        sendShellInput("swipe " + x1.toString() + " " + y1.toString() + " " + x2.toString() + " " + y2.toString());
+        sendShellInput("swipe " + x1.toString() + " " + y1.toString() + " " + x2.toString() + " " + y2.toString() + " " + duration.toString());
     }
 
     public void shellTap(Integer x, Integer y) {


### PR DESCRIPTION
Previously, when swipe gestures were performed by the accessibility service, they were all handled in the same thread, which meant that no swipes were overlapped, as each individual gesture wouldn't be executed until the previous one was completed. However, with the recent revamp of the Mouse Emulation Engine to be ADB-based, gestures are now handled on a parallel thread. This has resulted in the overlapping of swipes, as the key listener process continues to add extra swipes to the queue while a single movement is being executed, leading to an extremely large and almost endless scroll.

The overlapping of swipes was also the cause of the "ghost clicks" bug, as the operating system itself interpreted multiple swipes that are extremely close to each other as a standard tap. To address this issue, I proposed to put the main thread to sleep for the same amount of time each swipe would take to complete, before making another call to the system shell to perform a new gesture. As a result, the scroll now stops immediately after the key is released, with no extra delay or latency, no matter how long the key was pressed. 

Overall experience is almost identical to the one which was achieved by using the Accessibility Service.

Note: Some now unused code lines were deleted, but I am aware that it is preferred to just comment them out rather than erase them. However, I am planning to add a "Use Legacy Engine" option, so I'd like to keep them in a separate method.

Here is a live demonstration of the improvements, just a reminder that everything shown is entirely ADB-based.

https://youtu.be/B9BbyHxBgoU